### PR TITLE
Fixup cukes for 3.5 in devices

### DIFF
--- a/CalWebViewApp/config/cucumber.yml
+++ b/CalWebViewApp/config/cucumber.yml
@@ -27,3 +27,4 @@ default: APP="./CalWebView-cal.app" -p common
 ### DEVICE ###
 device_common: -p common BUNDLE_ID=com.xamarin.CalWebView-cal
 hat:   DEVICE_TARGET=<%= devices[:hat][:udid] %> DEVICE_ENDPOINT=<%= devices[:hat][:ip] %> -p device_common
+neptune:   DEVICE_TARGET=<%= devices[:neptune][:udid] %> DEVICE_ENDPOINT=<%= devices[:neptune][:ip] %> -p device_common

--- a/CalWebViewApp/features/pages/tabbar.rb
+++ b/CalWebViewApp/features/pages/tabbar.rb
@@ -25,7 +25,15 @@ module WebViewApp
       end
 
       touch(qstr)
-      step_pause
+
+      with_active_page do |page|
+        qstr = page.query_str
+        options = wait_options('Waiting for page to load')
+        wait_for(options) do
+          res = query(qstr, :isLoading)
+          !res.empty? && res.first.to_i == 0
+        end
+      end
     end
 
     def active_page

--- a/CalWebViewApp/features/step_definitions/css_steps.rb
+++ b/CalWebViewApp/features/step_definitions/css_steps.rb
@@ -8,9 +8,22 @@ Then(/^I can query for hrefs with css$/) do
 end
 
 Then(/^I can query for the body with css$/) do
-  page = page(WebViewApp::TabBar).active_page
-  res = query(page.query_str("css:'body'"))
-  expect(res.count).to be == 1
+  page(WebViewApp::TabBar).with_active_page do |page|
+    qstr = page.query_str("css:'body'")
+    visible = lambda {
+      query(qstr).count == 1
+    }
+
+    counter = 0
+    loop do
+      break if visible.call || counter == 4
+      scroll(page.query_str, :down)
+      step_pause
+      counter = counter + 1
+    end
+    res = query(qstr)
+    expect(res.count).to be == 1
+  end
 end
 
 # 3.5in iPhones will only show 2; all others will show 3

--- a/CalWebViewApp/features/step_definitions/scrolling_steps.rb
+++ b/CalWebViewApp/features/step_definitions/scrolling_steps.rb
@@ -75,6 +75,11 @@ And(/^I can see the (first|last) name text input field$/) do |input_field_id|
       step_pause
       counter = counter + 1
     end
-  end
 
+    # Visibility heuristic is failing.  Input field is _behind_ the tabbar.
+    if iphone_35in?
+      scroll(page.query_str, :down)
+      step_pause
+    end
+  end
 end

--- a/CalWebViewApp/features/step_definitions/xpath_steps.rb
+++ b/CalWebViewApp/features/step_definitions/xpath_steps.rb
@@ -10,7 +10,19 @@ end
 
 And(/^I can query for the body with xpath$/) do
   page(WebViewApp::TabBar).with_active_page do |page|
-    res = query(page.query_str("xpath:'//body'"))
+    qstr = page.query_str("xpath:'//body'")
+    visible = lambda {
+      query(qstr).count == 1
+    }
+
+    counter = 0
+    loop do
+      break if visible.call || counter == 4
+      scroll(page.query_str, :down)
+      step_pause
+      counter = counter + 1
+    end
+    res = query(qstr)
     expect(res.count).to be == 1
   end
 end


### PR DESCRIPTION
### Motivation

Failing tests on 3.5 in devices.

* https://testcloud.xamarin.com/test/90e3934e-143e-48e0-910e-95a64c975a69/

1. Center of 'body' is not visible on 3.5 devices; scroll until it is.
2. Visibility heuristic fails for last name input view - it is behind the tab bar yet reported as visible.  Fixed by scrolling down 1 extra time on 3.5 devices.

Fixed:  https://testcloud.xamarin.com/test/0626b08a-ba28-4dc9-9563-6a0dedc4ffae/