### PR TITLE
Update links for iframes and use remote URLs

### DIFF
--- a/CalWebViewApp/CalWebViewApp/XamUIWebViewController.m
+++ b/CalWebViewApp/CalWebViewApp/XamUIWebViewController.m
@@ -77,9 +77,9 @@ typedef enum : NSUInteger {
     UIWebView *webView = self.webView;
     [self.view addSubview:webView];
 
-    NSString *path = [[NSBundle mainBundle] pathForResource:@"page"
-                                                     ofType:@"html"];
-    NSURL *url = [NSURL fileURLWithPath:path];
+    NSString *page = @"https://calabash-ci.macminicolo.net/CalWebViewApp/page.html";
+    NSURL *url = [NSURL URLWithString:page];
+
     [self.webView loadRequest:[NSURLRequest requestWithURL:url]];
   }
   [super viewDidAppear:animated];

--- a/CalWebViewApp/CalWebViewApp/XamWKWebViewController.m
+++ b/CalWebViewApp/CalWebViewApp/XamWKWebViewController.m
@@ -227,17 +227,8 @@ typedef enum : NSUInteger {
     UIView<FLWebViewProvider> *webView = self.webView;
     [self.view addSubview:webView];
 
-    // http://www.openradar.me/radar?id=5839348817723392
-    // WKWebKit cannot load .html from a file on iOS Devices.
-
-#if TARGET_IPHONE_SIMULATOR
-    NSString *path = [[NSBundle mainBundle] pathForResource:@"page"
-                                                     ofType:@"html"];
-    NSURL *url = [NSURL fileURLWithPath:path];
-#else
-    NSString *page = @"https://cdn.rawgit.com/calabash/ios-webview-test-app/master/CalWebViewApp/CalWebViewApp/page.html";
+    NSString *page = @"https://calabash-ci.macminicolo.net/CalWebViewApp/page.html";
     NSURL *url = [NSURL URLWithString:page];
-#endif
 
     [self.webView loadRequest:[NSURLRequest requestWithURL:url]];
   }

--- a/CalWebViewApp/CalWebViewApp/iframe.html
+++ b/CalWebViewApp/CalWebViewApp/iframe.html
@@ -1,19 +1,20 @@
 <!DOCTYPE html>
   <head>
-    <title>Calabash!</title>
+    <title>Calabash Same Domain</title>
     <link rel="stylesheet" href="/stylesheets/style.css">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" integrity="sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7" crossorigin="anonymous">
     <script type="text/javascript" src="https://code.jquery.com/jquery-2.2.0.min.js"></script>
     <script type="text/javascript" src="/javascripts/index.js"></script>
   </head>
   <body>
-    <h1>Calabash On the Same Domain!</h1>
-    <p>Welcome to Calabash!</p>
-    <input id="name" type="text" placeholder="name" class="form-control">
-    <input id="email" type="email" placeholder="email" class="form-control">
-    <input id="password" type="password" placeholder="password" class="form-control">
-    <textarea id="textarea" placeholder="opinions: everyone's got one" class="form-control"></textarea>
-    <button id="button" onclick="submitPressed()" class="btn btn-info">Submit!</button>
-    <h2 id="msg" style="display:none" class="label label-success">Woohoo!</h2>
+    <div id="same-domain">
+      <p>Same Domain iFrame</p>
+      <input id="name" type="text" placeholder="name" class="form-control">
+      <input id="email" type="email" placeholder="email" class="form-control">
+      <input id="password" type="password" placeholder="password" class="form-control">
+      <textarea id="textarea" placeholder="opinions: everyone's got one" class="form-control"></textarea>
+      <button id="button" onclick="submitPressed()" class="btn btn-info">Submit!</button>
+      <h2 id="msg" style="display:none" class="label label-success">Woohoo!</h2>
+    </div>
   </body>
 </html>

--- a/CalWebViewApp/CalWebViewApp/page.html
+++ b/CalWebViewApp/CalWebViewApp/page.html
@@ -3,9 +3,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0 maximum-scale=1.0, user-scalable=no" charset="UTF-8"/>
   <title>Calabash Page</title>
 </head>
+
 <style>
 h1 {margin-top: 44px;}
 </style>
+
 <body>
   <h1>H1 Header!</h1>
 
@@ -14,8 +16,9 @@ h1 {margin-top: 44px;}
   <div class='menu'>
     <span class='heading'>List of Links</span>
     <ul id="links">
-      <li id="external"> <a id="external" href='http://www.google.com'>An external link.  Don't touch!</a></li>
-      <li id="internal"> <a id="internal" href="#faq" onclick="function() { return true; };">An internal link.  Touch!</a></li>
+      <li id="external"> <a id="external-link" href='http://www.google.com'>An external link.  Don't touch!</a></li>
+      <li id="internal"> <a id="internal-link" href="#faq-link" onclick="function() { return true; };">An internal link.  Touch!</a></li>
+    </ul>
   </div>
 
   <div class='menu'>
@@ -40,7 +43,6 @@ h1 {margin-top: 44px;}
   <hr id="thick_blue_line" width="300" size="8" color="blue" >
   </br>
 
-
   <div class='menu'>
     <span id="secret_message" class='heading' style="display: none;">Let Op!</span>
     </br>
@@ -64,12 +66,12 @@ h1 {margin-top: 44px;}
 
 
   </br>
-  <hr id="green_stripe"" width="300" size="8" color="green" >
+  <hr id="green_stripe" width="300" size="8" color="green" >
   </br>
 
   <div class='menu'>
-    <span class='heading'><a id="faq">FAQ</a></span>
-    <ul id="faq">
+    <span class='heading'><a id="faq-link">FAQ</a></span>
+    <ul id="faq-list">
       <li id="calabash">What is a calabash anyway?</li>
       <li id="break">Isn't it time for a break?</li>
       <li id="coffee">Can I get you a coffee?</li>
@@ -77,10 +79,10 @@ h1 {margin-top: 44px;}
   </div>
 
   </br>
-  <hr id="brown_stripe"" width="300" size="8" color="brown" >
+  <hr id="brown_stripe" width="300" size="8" color="brown" >
   </br>
 
-  <form id='name'>
+  <form id='name' action="#">
     First name:<br>
     <input type="text" name="firstname" id='firstname'>
     <br>
@@ -92,22 +94,20 @@ h1 {margin-top: 44px;}
   <hr id="sapphire_line" width="300" size="8" color="sapphire" >
   </br>
 
-  <h1 style='text-align:center'>Below here is an iFrame</h1>
-  <strong>Here it comes!</strong>
+  <h1 style='text-align:center'>Here there be iFrames</h1>
+
   <br>
-  <div>
-    <iframe id="same-domain"
-            frameborder="2"
-            height="500"
-            src="https://calabash-ci.macminicolo.net/CalWebViewApp/iframe.html">
-    </iframe>
-    <iframe id="x-domain"
-            frameborder="2"
-            height="500"
-            src="https://cdn.rawgit.com/calabash/ios-webview-test-app/master/CalWebViewApp/CalWebViewApp/x-domain-iframe.html">
-    </iframe>
-  </div>
-  <p>Wasn't that great?</p>
+  <iframe id="same-domain"
+          frameborder="2"
+          height="500"
+          src="https://calabash-ci.macminicolo.net/CalWebViewApp/iframe.html">
+  </iframe>
+  <iframe id="x-domain"
+          frameborder="2"
+          height="500"
+          src="https://cdn.rawgit.com/calabash/ios-webview-test-app/master/CalWebViewApp/CalWebViewApp/x-domain-iframe.html">
+  </iframe>
+  <p>This is the end of the page.</p>
 
 </body>
 </html>

--- a/CalWebViewApp/CalWebViewApp/page.html
+++ b/CalWebViewApp/CalWebViewApp/page.html
@@ -96,13 +96,16 @@ h1 {margin-top: 44px;}
   <strong>Here it comes!</strong>
   <br>
   <div>
-    <iframe id="x-origin" frameborder="2"
-                          height="500"
-                          src="http://54.172.92.162:3111/">
+    <iframe id="same-domain"
+            frameborder="2"
+            height="500"
+            src="https://calabash-ci.macminicolo.net/CalWebViewApp/iframe.html">
     </iframe>
-    <iframe id="same-domain" frameborder="2"
-                             height="500"
-                             src="https://cdn.rawgit.com/calabash/ios-webview-test-app/master/CalWebViewApp/CalWebViewApp/iframe.html">
+    <iframe id="x-domain"
+            frameborder="2"
+            height="500"
+            src="https://cdn.rawgit.com/calabash/ios-webview-test-app/master/CalWebViewApp/CalWebViewApp/x-domain-iframe.html">
+    </iframe>
   </div>
   <p>Wasn't that great?</p>
 

--- a/CalWebViewApp/features/css.feature
+++ b/CalWebViewApp/features/css.feature
@@ -7,15 +7,15 @@ Feature: CSS API
     Given I am looking at the UIWebView tab
     And I can see the h1 header with css
     Then I can query for hrefs with css
-    And I can query for the body with css
     When I query with css I should see at least 1 unordered lists
+    And I can query for the body with css
 
   Scenario: Query WKWebView with css
     Given I am looking at the WKWebView tab
     And I can see the h1 header with css
     Then I can query for hrefs with css
-    Then I can query for the body with css
     When I query with css I should see at least 1 unordered lists
+    Then I can query for the body with css
 
   Scenario: Query UIWebView for li with id using css
     Given I am looking at the UIWebView tab

--- a/CalWebViewApp/features/steps/css_steps.rb
+++ b/CalWebViewApp/features/steps/css_steps.rb
@@ -42,7 +42,7 @@ end
 When(/^I touch the internal link with css$/) do
   page(WebViewApp::TabBar).with_active_page do |page|
     options = wait_options('Internal Link')
-    qstr = page.query_str("css:'a#internal'")
+    qstr = page.query_str("css:'a#internal-link'")
     wait_for(options) do
       !query(qstr).empty?
     end
@@ -56,7 +56,7 @@ Then(/^a query for the FAQ with css should succeed$/) do
   page = page(WebViewApp::TabBar).active_page
   options = wait_options('FAQ List')
   wait_for(options) do
-    !query(page.query_str("css:'ul#faq'")).empty?
+    !query(page.query_str("css:'ul#faq-list'")).empty?
   end
 end
 

--- a/CalWebViewApp/features/xpath.feature
+++ b/CalWebViewApp/features/xpath.feature
@@ -7,15 +7,15 @@ Feature: XPATH API
     Given I am looking at the UIWebView tab
     And I can see the h1 header with xpath
     Then I can query for hrefs with xpath
-    And I can query for the body with xpath
     When I query with xpath I should see at least 1 unordered lists
+    And I can query for the body with xpath
 
   Scenario: Query WKWebView with xpath
     Given I am looking at the WKWebView tab
     And I can see the h1 header with xpath
     Then I can query for hrefs with xpath
-    And I can query for the body with xpath
     When I query with xpath I should see at least 1 unordered lists
+    And I can query for the body with xpath
 
   Scenario: Query UIWebView for li with id using xpath
     Given I am looking at the UIWebView tab

--- a/CalWebViewApp/ios-webview-test-app.xcodeproj/project.pbxproj
+++ b/CalWebViewApp/ios-webview-test-app.xcodeproj/project.pbxproj
@@ -40,8 +40,6 @@
 		F56E5A4F1AC5914A005D7D0C /* FLWebViewLICENSE.md in Resources */ = {isa = PBXBuildFile; fileRef = F56E5A4B1AC55E1F005D7D0C /* FLWebViewLICENSE.md */; };
 		F56E5A511AC59583005D7D0C /* GlyphishLICENSE.md in Resources */ = {isa = PBXBuildFile; fileRef = F56E5A501AC59579005D7D0C /* GlyphishLICENSE.md */; };
 		F56E5A521AC59588005D7D0C /* GlyphishLICENSE.md in Resources */ = {isa = PBXBuildFile; fileRef = F56E5A501AC59579005D7D0C /* GlyphishLICENSE.md */; };
-		F56E5A541AC59786005D7D0C /* page.html in Resources */ = {isa = PBXBuildFile; fileRef = F56E5A531AC59779005D7D0C /* page.html */; };
-		F56E5A551AC5978B005D7D0C /* page.html in Resources */ = {isa = PBXBuildFile; fileRef = F56E5A531AC59779005D7D0C /* page.html */; };
 		a851e37816c4ddd975adbf58 /* XamUIWebViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = F52BFB281987EF8700299AEF /* XamUIWebViewController.m */; };
 		ab943fbf9d0ac91728d35abe /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F52BFB131987EF8700299AEF /* UIKit.framework */; };
 		cc8f9377c616d69147b3de31 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F52BFB2A1987EF8700299AEF /* Images.xcassets */; };
@@ -297,7 +295,6 @@
 				F52EA33D1C3AB38E00F5862B /* LaunchScreen.xib in Resources */,
 				F56E5A4E1AC59144005D7D0C /* FLWebViewLICENSE.md in Resources */,
 				F56E5A521AC59588005D7D0C /* GlyphishLICENSE.md in Resources */,
-				F56E5A541AC59786005D7D0C /* page.html in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -311,7 +308,6 @@
 				F52EA33C1C3AB38E00F5862B /* LaunchScreen.xib in Resources */,
 				F56E5A511AC59583005D7D0C /* GlyphishLICENSE.md in Resources */,
 				F56E5A4F1AC5914A005D7D0C /* FLWebViewLICENSE.md in Resources */,
-				F56E5A551AC5978B005D7D0C /* page.html in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/bin/ci/jenkins/run.sh
+++ b/bin/ci/jenkins/run.sh
@@ -1,5 +1,17 @@
 #!/usr/bin/env bash
 
+set -e
+
+# Install page.hmtl and iframe.html
+IFRAME_SOURCE="CalWebViewApp/CalWebViewApp/iframe.html"
+PAGE_SOURCE="CalWebViewApp/CalWebViewApp/page.html"
+
+IFRAME_TARGET="/Library/Server/Web/Data/Sites/Default/CalWebViewApp/iframe.html"
+PAGE_TARGET="/Library/Server/Web/Data/Sites/Default/CalWebViewApp/page.html"
+
+cp "${IFRAME_SOURCE}" "${IFRAME_TARGET}"
+cp "${PAGE_SOURCE}" "${PAGE_TARGET}"
+
 bundle update
 
 bin/ci/install-keychain.sh


### PR DESCRIPTION
### Motivation

Progress on **Need SSL Certs + move x-domain to separate file** [#137](https://github.com/xamarinhq/test-cloud-frameworks/issues/137)

* Installed https certs on CI server.
* Create new x-domain-iframe.html file
* Updated page.html and iframes for clarity/style
* UIWebView use remote pages for iOS Simulators and Devices
* WKWebView use remote pages for iOS Simulators
* Naive strategy for keeping files on CI server up to date.