### PR TITLE
Increase page load timeout in CI and on XTC

### DIFF
--- a/CalWebViewApp/features/pages/tabbar.rb
+++ b/CalWebViewApp/features/pages/tabbar.rb
@@ -44,12 +44,14 @@ module WebViewApp
       with_active_page do |page|
         qstr = page.query_str
 
-        if RunLoop::Environment.ci? ||
-            RunLoop::Environment.xtc?
+        if RunLoop::Environment.xtc?
+          timeout = 45
+        elsif RunLoop::Environment.ci?
           timeout = 30
         else
           timeout = 15
         end
+
         options = wait_options('Waiting for page to load',
                                {:timeout => timeout})
         wait_for(options) do

--- a/CalWebViewApp/features/pages/tabbar.rb
+++ b/CalWebViewApp/features/pages/tabbar.rb
@@ -46,6 +46,8 @@ module WebViewApp
 
         if RunLoop::Environment.xtc?
           timeout = 45
+        elsif RunLoop::Environment.travis?
+          timeout = 60
         elsif RunLoop::Environment.ci?
           timeout = 45
         else

--- a/CalWebViewApp/features/pages/tabbar.rb
+++ b/CalWebViewApp/features/pages/tabbar.rb
@@ -47,7 +47,7 @@ module WebViewApp
         if RunLoop::Environment.xtc?
           timeout = 45
         elsif RunLoop::Environment.ci?
-          timeout = 30
+          timeout = 45
         else
           timeout = 15
         end


### PR DESCRIPTION
### Motivation

The WKWebView is slow to load on older machines in the XTC.

Increasing the timeout to 45 (from 30) seconds.