### PR TITLE
Jenkins: uninstall calabash-cucumber and run_loop before bundle

### DIFF
--- a/bin/ci/jenkins/run.sh
+++ b/bin/ci/jenkins/run.sh
@@ -12,6 +12,10 @@ PAGE_TARGET="/Library/Server/Web/Data/Sites/Default/CalWebViewApp/page.html"
 cp "${IFRAME_SOURCE}" "${IFRAME_TARGET}"
 cp "${PAGE_SOURCE}" "${PAGE_TARGET}"
 
+gem update --system
+gem uninstall -Vax --force --no-abort-on-dependent calabash-cucumber
+gem uninstall -Vax --force --no-abort-on-dependent run_loop
+
 bundle update
 
 bin/ci/install-keychain.sh


### PR DESCRIPTION
Other jobs install calabash-cucumber and run-loop versions that are not
compatible with this repo's Gemfile