### PR TITLE
App: update URLs to new calabash-ci.xyz domain

### DIFF
--- a/CalWebViewApp/CalWebViewApp/XamSafariWebViewController.m
+++ b/CalWebViewApp/CalWebViewApp/XamSafariWebViewController.m
@@ -5,7 +5,7 @@
 #pragma mark - Memory Management
 
 - (instancetype) init {
-  NSString *page = @"https://calabash-ci.macminicolo.net/CalWebViewApp/page.html";
+  NSString *page = @"https://calabash-ci.xyz/CalWebViewApp/page.html";
   NSURL *url = [NSURL URLWithString:page];
   self = [super initWithURL:url];
   if (self) {

--- a/CalWebViewApp/CalWebViewApp/XamUIWebViewController.m
+++ b/CalWebViewApp/CalWebViewApp/XamUIWebViewController.m
@@ -77,7 +77,7 @@ typedef enum : NSUInteger {
     UIWebView *webView = self.webView;
     [self.view addSubview:webView];
 
-    NSString *page = @"https://calabash-ci.macminicolo.net/CalWebViewApp/page.html";
+    NSString *page = @"https://calabash-ci.xyz/CalWebViewApp/page.html";
     NSURL *url = [NSURL URLWithString:page];
 
     [self.webView loadRequest:[NSURLRequest requestWithURL:url]];

--- a/CalWebViewApp/CalWebViewApp/XamWKWebViewController.m
+++ b/CalWebViewApp/CalWebViewApp/XamWKWebViewController.m
@@ -227,7 +227,7 @@ typedef enum : NSUInteger {
     UIView<FLWebViewProvider> *webView = self.webView;
     [self.view addSubview:webView];
 
-    NSString *page = @"https://calabash-ci.macminicolo.net/CalWebViewApp/page.html";
+    NSString *page = @"https://calabash-ci.xyz/CalWebViewApp/page.html";
     NSURL *url = [NSURL URLWithString:page];
 
     [self.webView loadRequest:[NSURLRequest requestWithURL:url]];

--- a/CalWebViewApp/CalWebViewApp/page.html
+++ b/CalWebViewApp/CalWebViewApp/page.html
@@ -100,7 +100,7 @@ h1 {margin-top: 44px;}
   <iframe id="same-domain"
           frameborder="2"
           height="500"
-          src="https://calabash-ci.macminicolo.net/CalWebViewApp/iframe.html">
+          src="https://calabash-ci.xyz/CalWebViewApp/iframe.html">
   </iframe>
   <iframe id="x-domain"
           frameborder="2"

--- a/CalWebViewApp/bin/publish.sh
+++ b/CalWebViewApp/bin/publish.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-SERVER=calabash-ci.macminicolo.net
+SERVER=calabash-ci.xyz
 
 IFRAME_SOURCE="CalWebViewApp/iframe.html"
 PAGE_SOURCE="CalWebViewApp/page.html"
@@ -8,6 +8,5 @@ PAGE_SOURCE="CalWebViewApp/page.html"
 IFRAME_TARGET="/Library/Server/Web/Data/Sites/Default/CalWebViewApp/iframe.html"
 PAGE_TARGET="/Library/Server/Web/Data/Sites/Default/CalWebViewApp/page.html"
 
-scp "${IFRAME_SOURCE}" jenkins@calabash-ci.macminicolo.net:${IFRAME_TARGET}
-scp "${PAGE_SOURCE}" jenkins@calabash-ci.macminicolo.net:${PAGE_TARGET}
-
+scp "${IFRAME_SOURCE}" jenkins@${SERVER}:${IFRAME_TARGET}
+scp "${PAGE_SOURCE}" jenkins@${SERVER}:${PAGE_TARGET}


### PR DESCRIPTION
### Motivation

Progress on:

* Transfer Calabash CI Mac Mini to new data center [VSTS](https://msmobilecenter.visualstudio.com/Mobile-Center/_workitems/edit/29321)