### PR TITLE
Fixed some failing test steps

### DIFF
--- a/CalWebViewApp/features/steps/css_steps.rb
+++ b/CalWebViewApp/features/steps/css_steps.rb
@@ -57,6 +57,7 @@ Then(/^a query for the FAQ with css should succeed$/) do
   page = page(WebViewApp::TabBar).active_page
   options = wait_options('FAQ List')
   wait_for(options) do
+    scroll("scrollView", :down)
     !query(page.query_str("css:'ul#faq-list'")).empty?
   end
 end

--- a/CalWebViewApp/features/steps/scrolling_steps.rb
+++ b/CalWebViewApp/features/steps/scrolling_steps.rb
@@ -41,6 +41,9 @@ And(/^I can see the green line with (css|xpath)$/) do |api|
       step_pause
       counter = counter + 1
     end
+
+    # Pause test to allow scrolling to finish
+    sleep(1.0)
   end
 end
 
@@ -81,5 +84,7 @@ And(/^I can see the (first|last) name text input field$/) do |input_field_id|
       scroll(page.query_str, :down)
       step_pause
     end
+
+    sleep 1.0
   end
 end

--- a/CalWebViewApp/features/steps/xpath_steps.rb
+++ b/CalWebViewApp/features/steps/xpath_steps.rb
@@ -56,26 +56,10 @@ end
 Then(/^a query for the FAQ with xpath should succeed$/) do
   page(WebViewApp::TabBar).with_active_page do |page|
     qstr = page.query_str("xpath:'//span/a[contains(@id,\"faq\")]'")
-
-    is_wkwebview = qstr[/WKWebView/,0]
-
-    if xamarin_test_cloud?
-       xcode_lte_611 = false
-    else
-      xcode_version = RunLoop::Xcode.new.version
-      xcode_lte_611 = xcode_version <= RunLoop::Version.new("6.1.1")
-    end
-
-    if xcode_lte_611 && is_wkwebview
-      puts %Q{
-Detecting Xcode <= 6.1.1 and a WKWebView!
-
-Skipping test because link is not touchable.
-}
-      $stdout.flush
-    else
-      res = query(qstr)
-      expect(res.count).to be == 1
+    sleep(1.0)
+    options = wait_options('FAQ')
+    wait_for(options) do
+      !query(qstr).empty?
     end
   end
 end


### PR DESCRIPTION
Some of the tests were failing due to reasons like insufficient scroll or pause until scrolling animation ends. Added delays and removed old unnecessary logic.