### PR TITLE
Update ruby test env and respond to Jenkins reinstall

### DIFF
--- a/CalWebViewApp/Gemfile
+++ b/CalWebViewApp/Gemfile
@@ -1,14 +1,15 @@
 source "https://rubygems.org"
 
 gem "calabash-cucumber", :github => "calabash/calabash-ios", :branch => "develop"
+gem "cucumber", "2.99.0"
 gem "run_loop", :github => "calabash/run_loop", :branch => "develop"
+gem "json", "1.8.6"
 gem "briar", "~> 2.0"
 gem "luffa", "~> 1.0", ">= 1.0.2"
 
 # Keep these sync'd with config/xtc-other-gems.rb
 gem "rspec", "~> 3.0"
 gem "xamarin-test-cloud", "~> 2.1"
-gem "cucumber", "~> 2.0"
 
 gem "xcpretty"
 gem "pry"

--- a/CalWebViewApp/Gemfile.lock
+++ b/CalWebViewApp/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: git://github.com/calabash/calabash-ios.git
-  revision: 840386d857d42aa1703064f0b6beed082c31f400
+  revision: 435dba70b0c82278caf8b5a7ef4e696490e8d98e
   branch: develop
   specs:
-    calabash-cucumber (0.21.4)
+    calabash-cucumber (0.21.6)
       awesome_print
       bundler (~> 1.3)
       clipboard (~> 1.0)
@@ -12,21 +12,21 @@ GIT
       geocoder (>= 1.1.8, < 2.0)
       httpclient (>= 2.7.1, < 3.0)
       json
-      run_loop (>= 2.6.3, < 3.0)
+      run_loop (>= 3.0, < 4.0)
       slowhandcuke (~> 0.0.3)
 
 GIT
   remote: git://github.com/calabash/run_loop.git
-  revision: 6477521435b9e050bca7090dacb00bab7e83e563
+  revision: 4759d308f7c6bf0f629905725c9277ea4b09007f
   branch: develop
   specs:
-    run_loop (2.6.4)
+    run_loop (3.0.1)
       CFPropertyList (~> 2.2)
       awesome_print (~> 1.2)
       command_runner_ng (>= 0.0.2)
       httpclient (>= 2.7.1, < 3.0)
       i18n (>= 0.7.0, < 1.0)
-      json (~> 1.8)
+      json
       thor (>= 0.18.1, < 1.0)
 
 GEM
@@ -46,9 +46,9 @@ GEM
       retriable
       xamarin-test-cloud
     builder (3.2.3)
-    clipboard (1.1.1)
+    clipboard (1.1.2)
     coderay (1.1.2)
-    command_runner_ng (0.1.3)
+    command_runner_ng (0.1.4)
     concurrent-ruby (1.0.5)
     cucumber (2.99.0)
       builder (>= 2.1.2)
@@ -62,9 +62,9 @@ GEM
       gherkin (~> 4.0)
     cucumber-wire (0.0.1)
     diff-lcs (1.3)
-    dotenv (2.2.1)
+    dotenv (2.5.0)
     edn (1.1.1)
-    geocoder (1.4.7)
+    geocoder (1.5.0)
     gherkin (4.1.3)
     httpclient (2.8.3)
     i18n (0.9.5)
@@ -86,24 +86,24 @@ GEM
     pry-nav (0.2.4)
       pry (>= 0.9.10, < 0.11.0)
     rainbow (2.1.0)
-    rake (12.3.0)
+    rake (12.3.1)
     rbx-require-relative (0.0.9)
     retriable (2.0.2)
     rouge (2.0.7)
-    rspec (3.7.0)
-      rspec-core (~> 3.7.0)
-      rspec-expectations (~> 3.7.0)
-      rspec-mocks (~> 3.7.0)
-    rspec-core (3.7.1)
-      rspec-support (~> 3.7.0)
-    rspec-expectations (3.7.0)
+    rspec (3.8.0)
+      rspec-core (~> 3.8.0)
+      rspec-expectations (~> 3.8.0)
+      rspec-mocks (~> 3.8.0)
+    rspec-core (3.8.0)
+      rspec-support (~> 3.8.0)
+    rspec-expectations (3.8.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.7.0)
-    rspec-mocks (3.7.0)
+      rspec-support (~> 3.8.0)
+    rspec-mocks (3.8.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.7.0)
-    rspec-support (3.7.1)
-    rubyzip (1.2.1)
+      rspec-support (~> 3.8.0)
+    rspec-support (3.8.0)
+    rubyzip (1.2.2)
     slop (3.6.0)
     slowhandcuke (0.0.3)
       cucumber
@@ -116,7 +116,7 @@ GEM
       retriable (>= 1.3.3.1, < 2.1)
       rubyzip (~> 1.1)
       thor (>= 0.18.1, < 1.0)
-    xcpretty (0.2.8)
+    xcpretty (0.3.0)
       rouge (~> 2.0.7)
 
 PLATFORMS
@@ -125,7 +125,8 @@ PLATFORMS
 DEPENDENCIES
   briar (~> 2.0)
   calabash-cucumber!
-  cucumber (~> 2.0)
+  cucumber (= 2.99.0)
+  json (= 1.8.6)
   luffa (~> 1.0, >= 1.0.2)
   pry
   pry-nav
@@ -135,4 +136,4 @@ DEPENDENCIES
   xcpretty
 
 BUNDLED WITH
-   1.16.1
+   1.16.4

--- a/CalWebViewApp/bin/make/ipa-cal.sh
+++ b/CalWebViewApp/bin/make/ipa-cal.sh
@@ -127,7 +127,8 @@ fi
 cat >"${XTC_DIR}/Gemfile" <<EOF
 source "https://rubygems.org"
 
-gem "calabash-cucumber"
+gem "calabash-cucumber", "2.99.0"
+gem "json", "1.8.6"
 EOF
 
 cat "config/xtc-other-gems.rb" >> "${XTC_DIR}/Gemfile"

--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,6 @@ source "https://rubygems.org"
 gem "luffa"
 gem "bundler"
 gem "run_loop", github: "calabash/run_loop", branch: "develop"
+gem "json", "1.8.6"
 gem "xcpretty"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,15 @@
 GIT
   remote: git://github.com/calabash/run_loop.git
-  revision: 3d9292fd6a920eae54ada69665353544486e93ce
+  revision: 4759d308f7c6bf0f629905725c9277ea4b09007f
   branch: develop
   specs:
-    run_loop (2.6.4)
+    run_loop (3.0.1)
       CFPropertyList (~> 2.2)
       awesome_print (~> 1.2)
       command_runner_ng (>= 0.0.2)
       httpclient (>= 2.7.1, < 3.0)
       i18n (>= 0.7.0, < 1.0)
-      json (~> 1.8)
+      json
       thor (>= 0.18.1, < 1.0)
 
 GEM
@@ -17,7 +17,7 @@ GEM
   specs:
     CFPropertyList (2.3.6)
     awesome_print (1.8.0)
-    command_runner_ng (0.1.3)
+    command_runner_ng (0.1.4)
     concurrent-ruby (1.0.5)
     httpclient (2.8.3)
     i18n (0.9.5)
@@ -31,7 +31,7 @@ GEM
     retriable (2.0.2)
     rouge (2.0.7)
     thor (0.20.0)
-    xcpretty (0.2.8)
+    xcpretty (0.3.0)
       rouge (~> 2.0.7)
 
 PLATFORMS
@@ -39,9 +39,10 @@ PLATFORMS
 
 DEPENDENCIES
   bundler
+  json (= 1.8.6)
   luffa
   run_loop!
   xcpretty
 
 BUNDLED WITH
-   1.16.1
+   1.16.4

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,6 @@ pipeline {
 
   options {
     disableConcurrentBuilds()
-    timestamps()
     buildDiscarder(logRotator(numToKeepStr: '10'))
     timeout(time: 75, unit: 'MINUTES')
   }


### PR DESCRIPTION
### Motivation

Jenkins has been reinstalled and the timestamper plug-in removed.

Calabash iOS will soon be agnostic re: the cucumber version.

run_loop will soon be agnostic re: the json version