### PR TITLE
Increase test shell timeout

### DIFF
--- a/CalWebViewApp/features/support/env.rb
+++ b/CalWebViewApp/features/support/env.rb
@@ -8,3 +8,5 @@ require 'rspec'
 unless ENV['XAMARIN_TEST_CLOUD']
   require 'pry'
 end
+
+RunLoop::Shell::DEFAULT_OPTIONS[:timeout] = 60


### PR DESCRIPTION
There is a failures during CI testing related to the interrupting of shell commands. This issue may occurs approximately one time per two CI builds.
Example of failure:
![image](https://user-images.githubusercontent.com/28828957/66659200-aff0b180-ec4b-11e9-8b6b-091024a010ae.png)

In order to fix it we have to increase default shell timeout used for builds from 30 sec up to 60 sec as described [here](https://github.com/calabash/run_loop/blob/4a7f65f5c4fd14485250f19852e3777d1365b2d4/lib/run_loop/shell.rb#L8-L17).