### PR TITLE
Upgrade bundler version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
 gem "luffa"
-gem "bundler"
+gem "bundler", "2.0.2"
 gem "run_loop", github: "calabash/run_loop", branch: "develop"
 gem "json", "1.8.6"
 gem "xcpretty"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,7 +62,7 @@ jobs:
 
     - script: |
         gem uninstall bundler
-        gem install bundler -v 1.17.3
+        gem install bundler -v 2.0.2
       displayName: "Install bundler"
 
     - script: |


### PR DESCRIPTION
There is failure on `Ruby info` step in CI builds. It's caused by the fact that `bundler@1.17.3` is not works properly. We upgrade version of `bundler` gem used during CI testing up to `2.0.2`